### PR TITLE
Use a list of versions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,8 @@
 use std::path::Path;
 use std::process::Command;
 
-// TODO:
-// - Add subcommands for other purposes
-// - Take parameters to support arbitrary versions without changing the source
-fn main() {
+// TODO: Take parameters to support arbitrary versions without changing the source
+fn stack_path () {
     let output = Command::new("sh")
         .arg("-c")
         .arg("stack path --compiler-tools-bin")
@@ -17,11 +15,21 @@ fn main() {
     // The Stack compiler tools looks something like
     // ~/.stack/compiler-tools/x86_64-linux-tinfo6/<ghc version>/bin
     // So we drop the `/bin` and `/<ghc-version>` directories
-    let stack_root = Path::new(stack_root.trim()).parent().unwrap().parent().unwrap();
+    let stack_root = Path::new(stack_root.trim())
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap();
 
     // And then add a few other ones that we one
-    let a = stack_root.clone().join(Path::new("ghc-9.2.5/bin"));
-    let b = stack_root.clone().join(Path::new("ghc-8.10.7/bin"));
+    let versions = [Path::new("ghc-9.2.5/bin"), Path::new("ghc-8.10.7/bin")];
 
-    println!("{}:{}", a.to_str().unwrap(), b.to_str().unwrap());
+    let paths = versions.map(|p| stack_root.clone().join(p).to_str().unwrap());
+
+    println!("{}", paths.join(":"));
+}
+
+// TODO: Add subcommands for other purposes
+fn main() {
+    stack_path()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::process::Command;
 
 // TODO: Take parameters to support arbitrary versions without changing the source
-fn stack_path () {
+fn stack_copiler_tools_path() -> String {
     let output = Command::new("sh")
         .arg("-c")
         .arg("stack path --compiler-tools-bin")
@@ -22,14 +22,14 @@ fn stack_path () {
         .unwrap();
 
     // And then add a few other ones that we one
-    let versions = [Path::new("ghc-9.2.5/bin"), Path::new("ghc-8.10.7/bin")];
+    let versions = ["ghc-9.2.5/bin", "ghc-8.10.7/bin"];
 
-    let paths = versions.map(|p| stack_root.clone().join(p).to_str().unwrap());
+    let paths = versions.map(|p| stack_root.join(Path::new(p)).to_str().unwrap().to_owned());
 
-    println!("{}", paths.join(":"));
+    paths.join(":")
 }
 
 // TODO: Add subcommands for other purposes
 fn main() {
-    stack_path()
+    println!("{}", stack_copiler_tools_path())
 }


### PR DESCRIPTION
```
$ cargo run
   Compiling env-tools v0.1.0 (/home/bb8/dev/env-tools)
error[E0515]: cannot return value referencing temporary value
  --> src/main.rs:27:34
   |
27 |     let paths = versions.map(|p| stack_root.clone().join(p).to_str().unwrap());
   |                                  --------------------------^^^^^^^^^^^^^^^^^^
   |                                  |
   |                                  returns a value referencing data owned by the current function
   |                                  temporary value created here

For more information about this error, try `rustc --explain E0515`.
error: could not compile `env-tools` due to previous error
```